### PR TITLE
Fix face detect when no faces are detected

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ numpy==1.26.4
 omegaconf==2.3.0
 onnx2torch==1.5.14
 onnx==1.16.1
-onnxruntime==1.18.0
+onnxruntime-gpu==1.18.0
 opencv-contrib-python==4.9.0.80
 opencv-python-headless==4.9.0.80
 opencv-python==4.9.0.80


### PR DESCRIPTION
When I tried Hallo with my pfp, it kept throwing errors. I tracked down the error to this detect faces part, and apparently it couldn't find my face. As a fallback, we can use the whole image as the face and it seems to work.

I also had issues getting CUDA to work, ONNX kept saying the CUDA provider was not available. Removing `onnxruntime` and installing only `onnxruntime-gpu` fixes this.