### PR TITLE
Fix bug of beta_schedule

### DIFF
--- a/configs/train/stage1.yaml
+++ b/configs/train/stage1.yaml
@@ -34,7 +34,7 @@ noise_scheduler_kwargs:
   num_train_timesteps: 1000
   beta_start: 0.00085
   beta_end: 0.012
-  beta_schedule: "scaled_linear"
+  beta_schedule: "linear"
   steps_offset: 1
   clip_sample: false
 


### PR DESCRIPTION
Unify the beta_schedule for stages 1, stages 2, and inference to make the generated video more stable.